### PR TITLE
fix teste teste de integracao agora procurando o h2, desativa subir u…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main,dev ]
 
 jobs:
   build-and-test:

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	compileOnly 'org.projectlombok:lombok:1.18.32'
 	annotationProcessor 'org.projectlombok:lombok:1.18.32'

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+  liquibase:
+    enabled: false


### PR DESCRIPTION
Atualizações do Fluxo de CI/CD:

    [.github/workflows/ci-cd.yml](https://www.google.com/search?q=diffhunk://%23diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L7-R7): Atualizamos o gatilho de pull_request para incluir a branch dev, além da main. Isso garante que as pull requests direcionadas à branch dev também acionem o pipeline de CI/CD.

Configuração de Testes:

    [src/test/resources/application.yml](https://www.google.com/search?q=diffhunk://%23diff-9505534937cc795b823f36b038529b4a0fc1cc060b9c14df770504a187e6ef69R1-R12): Adicionamos uma nova configuração para um banco de dados H2 em memória para ser usado durante os testes. Isso inclui detalhes de conexão do banco de dados, configurações do Hibernate e a desativação das migrações do Liquibase.